### PR TITLE
External db

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -10,9 +10,10 @@ services:
       - workflow.namespace.queue.prefix=conductor_queues
       - queues.dynomite.threads=10
       - queues.dynomite.nonQuorum.port=22122
-      - workflow.elasticsearch.url=es:9300
+      - workflow.elasticsearch.mode=memory
+      - workflow.elasticsearch.url=localhost:9300
       - workflow.elasticsearch.index.name=conductor
-      - loadSample=true      
+      - loadSample=true
     image: conductor:server
     build:
       context: ./server

--- a/docker/server/config/config-local.properties
+++ b/docker/server/config/config-local.properties
@@ -25,6 +25,11 @@ queues.dynomite.threads=10
 # For Dynomite, this is 22122 by default or the local redis-server port used by Dynomite.
 queues.dynomite.nonQuorum.port=22122
 
+# Search persistence model.  Possible values are memory and elasticsearch.
+#
+# memory : The search index is stored in memory.
+# elasticsearch : The search index is stored in an external elasticsearch store.
+workflow.elasticsearch.mode=memory
 
 # Transport address to elasticsearch
 workflow.elasticsearch.url=localhost:9300

--- a/docker/server/config/config.properties
+++ b/docker/server/config/config.properties
@@ -28,6 +28,11 @@ queues.dynomite.threads=10
 # For Dynomite, this is 22122 by default or the local redis-server port used by Dynomite.
 queues.dynomite.nonQuorum.port=22122
 
+# Search persistence model.  Possible values are memory and elasticsearch.
+#
+# memory : The search index is stored in memory.
+# elasticsearch : The search index is stored in an external elasticsearch store.
+workflow.elasticsearch.mode=elasticsearch
 
 # Transport address to elasticsearch
 workflow.elasticsearch.url=es:9300

--- a/server/src/main/java/com/netflix/conductor/server/ConductorServer.java
+++ b/server/src/main/java/com/netflix/conductor/server/ConductorServer.java
@@ -64,6 +64,10 @@ public class ConductorServer {
 	private enum DB {
 		redis, dynomite, memory
 	}
+
+	private enum SearchMode {
+		elasticsearch, memory
+	}
 	
 	private ServerModule sm;
 	
@@ -72,6 +76,8 @@ public class ConductorServer {
 	private ConductorConfig cc;
 	
 	private DB db;
+
+	private SearchMode mode;
 	
 	public ConductorServer(ConductorConfig cc) {
 		this.cc = cc;
@@ -84,6 +90,14 @@ public class ConductorServer {
 		}catch(IllegalArgumentException ie) {
 			logger.error("Invalid db name: " + dbstring + ", supported values are: redis, dynomite, memory");
 			System.exit(1);
+		}
+
+		String modestring = cc.getProperty("workflow.elasticsearch.mode", "memory");
+		try {
+			mode = SearchMode.valueOf(modestring);
+		}catch(IllegalArgumentException ie) {
+			logger.error("Invalid setting for workflow.elasticsearch.mode: " + modestring + ", supported values are: elasticsearch, memory");
+			System.exit(1);			
 		}
 		
 		if(!db.equals(DB.memory)) {
@@ -154,6 +168,11 @@ public class ConductorServer {
 			
 		case memory:
 			jedis = new JedisMock();
+		}
+		
+		switch (mode) {
+		case memory:
+
 			try {
 				EmbeddedElasticSearch.start();
 				if(cc.getProperty("workflow.elasticsearch.url", null) == null) {
@@ -166,9 +185,12 @@ public class ConductorServer {
 				logger.error("Error starting embedded elasticsearch.  Search functionality will be impacted: " + e.getMessage(), e);
 			}
 			logger.info("Starting conductor server using in memory data store");
+			break;			
+
+		case elasticsearch:
 			break;
 		}
-		
+
 		this.sm = new ServerModule(jedis, hs, cc);
 	}
 	


### PR DESCRIPTION
The purpose of this change is to allow us to configure the location of dynomite and elasticsearch separately.  Currently they're either both internal or both external.  We'd like to be able to run dynomite internally but maybe run elasticsearch in memory on the server node.