### PR TITLE
re-deploying to prod test

### DIFF
--- a/deploy.tmpl.nomad
+++ b/deploy.tmpl.nomad
@@ -7,7 +7,7 @@ job "conductor" {
   constraint {
     attribute = "${meta.hood}"
     // Options: [ corp | prod | shared ]
-    value     = "shared"
+    value     = "corp"
   }
 
   constraint {


### PR DESCRIPTION
Re-deploying conductor to the Corp-Test env to unblock testing and future deployments. 