### PR TITLE
CPEWF_TASK_ID fix

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/ParametersUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/ParametersUtils.java
@@ -59,9 +59,11 @@ public class ParametersUtils {
 	}
 	
 	public Map<String, Object> getTaskInputV2(Map<String, Object> input, Workflow workflow, String taskId, TaskDef taskDef) {
-		Map<String, Object> inputParams = new HashMap<>();
+		Map<String, Object> inputParams = null;
 		if(input != null) {
-			inputParams.putAll(input);
+			inputParams = clone(input);
+		} else {
+			inputParams = new HashMap<>();
 		}
 		if(taskDef != null && taskDef.getInputTemplate() != null) {
 			inputParams.putAll(clone(taskDef.getInputTemplate()));


### PR DESCRIPTION
The fix for the old task id being provided instead of new one in case the task is rescheduled. The current code matches the latest Netflix code