### PR TITLE
OWCOND-102 - Nats event handler refactoring. Take the subject name fr…

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/nats/NATSStreamObservableQueue.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/nats/NATSStreamObservableQueue.java
@@ -88,10 +88,10 @@ public class NATSStreamObservableQueue extends NATSAbstractQueue {
 			// Create subject/queue subscription if the queue has been provided
 			if (StringUtils.isNotEmpty(queue)) {
 				logger.info("No subscription. Creating a queue subscription. subject={}, queue={}", subject, queue);
-				subs = conn.subscribe(subject, queue, msg -> onMessage(subject, msg.getData()), subscriptionOptions);
+				subs = conn.subscribe(subject, queue, msg -> onMessage(msg.getSubject(), msg.getData()), subscriptionOptions);
 			} else {
 				logger.info("No subscription. Creating a pub/sub subscription. subject={}", subject);
-				subs = conn.subscribe(subject, msg -> onMessage(subject, msg.getData()), subscriptionOptions);
+				subs = conn.subscribe(subject, msg -> onMessage(msg.getSubject(), msg.getData()), subscriptionOptions);
 			}
 		} catch (Exception ex) {
 			logger.error("Subscription failed with " + ex.getMessage() + " for queueURI " + queueURI, ex);


### PR DESCRIPTION
…om the message and not from the class field. The case when class field is pattern, might be 'deluxe.*.*.*' but the subject in the message is actual name e.g. 'deluxe.datamovement.transfer.status'