### PR TITLE
Add workflow.system.task.http.isAsync config option

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
@@ -49,11 +49,13 @@ public class HttpTask extends GenericHttpTask {
 	public static final String NAME = "HTTP";
 	private static final String CONDITIONS_PARAMETER = "conditions";
 	private int unackTimeout;
+	private boolean isAsync;
 
 	@Inject
 	public HttpTask(RestClientManager rcm, Configuration config, ObjectMapper om, AuthManager auth) {
 		super(NAME, config, rcm, om, auth);
 		unackTimeout = config.getIntProperty("workflow.system.task.http.unack.timeout", 60);
+		isAsync = Boolean.getBoolean(config.getProperty("workflow.system.task.http.isAsync", "true"));
 		logger.debug("HttpTask initialized...");
 	}
 
@@ -153,7 +155,7 @@ public class HttpTask extends GenericHttpTask {
 
 	@Override
 	public boolean isAsync() {
-		return true;
+		return isAsync;
 	}
 
 	@Override

--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
@@ -55,7 +55,7 @@ public class HttpTask extends GenericHttpTask {
 	public HttpTask(RestClientManager rcm, Configuration config, ObjectMapper om, AuthManager auth) {
 		super(NAME, config, rcm, om, auth);
 		unackTimeout = config.getIntProperty("workflow.system.task.http.unack.timeout", 60);
-		isAsync = Boolean.getBoolean(config.getProperty("workflow.system.task.http.isAsync", "true"));
+		isAsync = Boolean.parseBoolean(config.getProperty("workflow.system.task.http.isAsync", "true"));
 		logger.debug("HttpTask initialized...");
 	}
 

--- a/deploy.tmpl.nomad
+++ b/deploy.tmpl.nomad
@@ -153,6 +153,7 @@ job "conductor" {
         workflow_system_task_worker_poll_timeout = "1000"
         workflow_system_task_worker_poll_frequency = "1000"
         workflow_system_task_worker_queue_size = "300"
+        workflow_system_task_http_isAsync = "false"
         workflow_system_task_http_unack_timeout = "300"
         workflow_sweeper_frequency = "500"
         workflow_sweeper_thread_count = 50


### PR DESCRIPTION
Add a `workflow.system.task.http.isAsync` configuration option (defaults to true, the current value) to `HttpTask` so that the result of the `HttpTask isAsync()` method can be set via a configuration value.