### PR TITLE
ONECOND-708: Reduce amount of logging

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -982,7 +982,7 @@ public class WorkflowExecutor {
 			if (tw.task != null) {
 				error += ", taskId=" + tw.task.getTaskId() + ", taskRefName=" + tw.task.getReferenceTaskName();
 			}
-			logger.error(error, tw);
+
 			terminate(def, workflow, tw);
 			return true;
 		}

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -982,7 +982,7 @@ public class WorkflowExecutor {
 			if (tw.task != null) {
 				error += ", taskId=" + tw.task.getTaskId() + ", taskRefName=" + tw.task.getReferenceTaskName();
 			}
-
+			logger.error(error, tw);
 			terminate(def, workflow, tw);
 			return true;
 		}

--- a/server/src/main/java/com/netflix/conductor/log4j/KeyValueLayout.java
+++ b/server/src/main/java/com/netflix/conductor/log4j/KeyValueLayout.java
@@ -89,7 +89,7 @@ public class KeyValueLayout extends Layout {
 
     @Override
     public boolean ignoresThrowable() {
-        return true;
+        return false; // See ONECOND-708: https://jira.d3nw.com/browse/ONECOND-708
     }
 
     @Override


### PR DESCRIPTION
The log messages referenced from https://jira.d3nw.com/browse/ONECOND-708 look to be because of the use of the `logger.error(String msg, Throwable t)` method. When a `Throwable` is provided and the stack trace is logged, the resulting log message contains newlines which result in the appearance of additional messages within Splunk.

It looks like this method is used elsewhere in the Conductor codebase. We need to decide whether to remove other uses of it or use a different method that removes the newlines from the underlying stack traces before logging the information.