### PR TITLE
Add $JAVA_OPTS

### DIFF
--- a/docker/server/bin/startup.sh
+++ b/docker/server/bin/startup.sh
@@ -33,4 +33,4 @@ do
 done
 
 # Run java in the foreground and stream messages directly to stdout
-exec java -Dlog4j.configuration="file:/app/config/log4j.properties" -jar conductor-server-*-all.jar $config_file
+exec java $JAVA_OPTS -Dlog4j.configuration="file:/app/config/log4j.properties" -jar conductor-server-*-all.jar $config_file


### PR DESCRIPTION
- Add an environment variable here to allow us to define some options to pass to the JVM.
- Also added `JAVA_OPTS` to the `owf-dev` vault with a value of `-Xmx512m` to specify a max heap size of 512MB.