### PR TITLE
ONECOND-775: Clean Metrics API

### DIFF
--- a/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
@@ -70,6 +70,14 @@ public class Monitors {
 		return counters;
 	}
 
+	public static Map<String, Map<Map<String, String>, AtomicLong>> getGauges() {
+		return gauges;
+	}
+
+	public static Map<String, Map<Map<String, String>, PercentileTimer>> getTimers() {
+		return timers;
+	}
+
 	/**
 	 * Increment a counter that is used to measure the rate at which some event
 	 * is occurring. Consider a simple queue, counters would be used to measure

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/InfoResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/InfoResource.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.metrics.Monitors;
 import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.histogram.PercentileTimer;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.slf4j.Logger;
@@ -35,6 +36,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import java.io.InputStream;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 /**
@@ -133,6 +135,7 @@ public class InfoResource {
 
 		return output;
 	}
+
 	@GET
 	@Path("/metrics")
 	@ApiOperation(value = "Get the metrics")
@@ -140,16 +143,32 @@ public class InfoResource {
 	public Map<String, Object> metrics() {
 		Map<String, Object> output = new TreeMap<>();
 
+		// Counters
 		Map<String, Map<Map<String, String>, Counter>> counters = Monitors.getCounters();
+
 		counters.forEach((name, map) -> {
 			map.forEach((tags, counter) -> {
-				// Concatenate all tags into single line: tag1.tag2.tagX excluding class name
-				String joined = tags.entrySet().stream()
-						.filter(entry -> !entry.getKey().equals("class"))
-						.map(Map.Entry::getValue).collect(Collectors.joining("."));
+				output.put(name + "|" + joinTags(tags) + ".counter", counter.count());
+			});
+		});
 
-				// Emit the counter name
-				output.put(name + "." + joined + ".counter", counter.count());
+		// Gauges
+		Map<String, Map<Map<String, String>, AtomicLong>> gauges = Monitors.getGauges();
+
+		gauges.forEach((name, map) -> {
+			map.forEach((tags, value) -> {
+				output.put(name + "|" + joinTags(tags) + ".value", value.get());
+			});
+		});
+
+		// Timers
+		Map<String, Map<Map<String, String>, PercentileTimer>> timers = Monitors.getTimers();
+
+		timers.forEach((name, map) -> {
+			map.forEach((tags, timer) -> {
+				String key = joinTags(tags);
+				output.put(name + "|" + key + ".count", timer.count());
+				output.put(name + "|" + key + ".totalTime", timer.totalTime());
 			});
 		});
 

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/InfoResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/InfoResource.java
@@ -143,9 +143,8 @@ public class InfoResource {
 	public Map<String, Object> metrics() {
 		Map<String, Object> output = new TreeMap<>();
 
+		// TODO(hueys): Remove this debug code once the set of metrics is finalized.
 		final boolean debug = true;
-
-		// TODO(hueys): This code could probably be cleaned up with some helper methods or lambdas.
 
 		// Debug: Counters
 		Map<String, Map<Map<String, String>, Counter>> counters = Monitors.getCounters();

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/InfoResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/InfoResource.java
@@ -155,4 +155,11 @@ public class InfoResource {
 
 		return output;
 	}
+
+	private String joinTags(Map<String, String> tags) {
+		// Concatenate all tags into single line: tag1.tag2.tagX excluding class name
+		return tags.entrySet().stream()
+			.filter(entry -> !entry.getKey().equals("class"))
+			.map(Map.Entry::getValue).collect(Collectors.joining("."));
+	}
 }

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/InfoResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/InfoResource.java
@@ -183,35 +183,22 @@ public class InfoResource {
 		}
 
 		// Workflow and Event Counters
+		Map<String, String> counterMap = new HashMap<>();
+
+		// Workflows
+		counterMap.put("workflow_completion", "workflows_completed");
+		counterMap.put("workflow_failure", "workflows_failed");
+		counterMap.put("workflow_start", "workflows_started");
+		counterMap.put("workflow_cancel", "workflows_canceled");
+		counterMap.put("workflow_restart", "workflows_restarted");
+
+		// Messages
+		counterMap.put("event_queue_messages_received", "messages_received");
+		counterMap.put("event_queue_messages_processed", "messages_processed");
+
 		counters.forEach((name, map) -> {
-			// Workflows
-			if (name.equals("workflow_completion")) {
-				output.put("deluxe.conductor.workflows_completed", sum(map));
-			}
-
-			if (name.equals("workflow_failure")) {
-				output.put("deluxe.conductor.workflows_failed", sum(map));
-			}
-
-			if (name.equals("workflow_start")) {
-				output.put("deluxe.conductor.workflows_started", sum(map));
-			}
-
-			if (name.equals("workflow_cancel")) {
-				output.put("deluxe.conductor.workflows_canceled", sum(map));
-			}
-
-			if (name.equals("workflow_restart")) {
-				output.put("deluxe.conductor.workflows_restarted", sum(map));
-			}
-
-			// Messages
-			if (name.equals("event_queue_messages_received")) {
-				output.put("deluxe.conductor.messages_received", sum(map));
-			}
-
-			if (name.equals("event_queue_messages_processed")) {
-				output.put("deluxe.conductor.messages_processed", sum(map));
+			if (counterMap.containsKey(name)) {
+				output.put("deluxe.conductor." + counterMap.get(name), sum(map));
 			}
 		});
 

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/InfoResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/InfoResource.java
@@ -117,6 +117,23 @@ public class InfoResource {
 	}
 
 	@GET
+	@Path("/metrics/counters")
+	@ApiOperation(value = "Get the counter metrics")
+	@Produces(MediaType.APPLICATION_JSON)
+	public Map<String, Object> counters() {
+		Map<String, Object> output = new TreeMap<>();
+
+		Map<String, Map<Map<String, String>, Counter>> counters = Monitors.getCounters();
+		counters.forEach((name, map) -> {
+			map.forEach((tags, counter) -> {
+				// Emit the counter name
+				output.put(name + "." + joinTags(tags) + ".counter", counter.count());
+			});
+		});
+
+		return output;
+	}
+	@GET
 	@Path("/metrics")
 	@ApiOperation(value = "Get the metrics")
 	@Produces(MediaType.APPLICATION_JSON)

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/InfoResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/InfoResource.java
@@ -183,39 +183,35 @@ public class InfoResource {
 		}
 
 		// Workflow and Event Counters
-		CounterSum total = (m) -> {
-			return m.values().stream().map(c -> {return c.count();}).mapToLong(i -> i).sum();
-		};
-
 		counters.forEach((name, map) -> {
 			// Workflows
 			if (name.equals("workflow_completion")) {
-				output.put("deluxe.conductor.workflows_completed", total.sum(map));
+				output.put("deluxe.conductor.workflows_completed", sum(map));
 			}
 
 			if (name.equals("workflow_failure")) {
-				output.put("deluxe.conductor.workflows_failed", total.sum(map));
+				output.put("deluxe.conductor.workflows_failed", sum(map));
 			}
 
 			if (name.equals("workflow_start")) {
-				output.put("deluxe.conductor.workflows_started", total.sum(map));
+				output.put("deluxe.conductor.workflows_started", sum(map));
 			}
 
 			if (name.equals("workflow_cancel")) {
-				output.put("deluxe.conductor.workflows_canceled", total.sum(map));
+				output.put("deluxe.conductor.workflows_canceled", sum(map));
 			}
 
 			if (name.equals("workflow_restart")) {
-				output.put("deluxe.conductor.workflows_restarted", total.sum(map));
+				output.put("deluxe.conductor.workflows_restarted", sum(map));
 			}
 
 			// Messages
 			if (name.equals("event_queue_messages_received")) {
-				output.put("deluxe.conductor.messages_received", total.sum(map));
+				output.put("deluxe.conductor.messages_received", sum(map));
 			}
 
 			if (name.equals("event_queue_messages_processed")) {
-				output.put("deluxe.conductor.messages_processed", total.sum(map));
+				output.put("deluxe.conductor.messages_processed", sum(map));
 			}
 		});
 
@@ -228,8 +224,9 @@ public class InfoResource {
 			.filter(entry -> !entry.getKey().equals("class"))
 			.map(Map.Entry::getValue).collect(Collectors.joining("."));
 	}
-}
 
-interface CounterSum {
-	public long sum(Map<Map<String, String>, Counter> counterMap);
+	// Return the sum of the Counter values in m
+	private long sum(Map<Map<String, String>, Counter> m) {
+		return m.values().stream().map(c -> {return c.count();}).mapToLong(i -> i).sum();
+	}
 }


### PR DESCRIPTION
- Updated the `/metrics` endpoint to return existing (and additional) metrics with a `debug` prefix
- Renamed the previous `/metrics` endpoint to `/metrics/counters`
- Added data to the result of `/metrics` to return the total number of workflows started, completed, failed, etc…
- Added data to the result of `/metrics` to return the total number of messages received and processed