### PR TITLE
ONECOND-794: Reset to restart workflow has delay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ ui/.settings
 dump.rdb
 .idea
 deploy.nomad
+.vscode
+bin

--- a/common/src/main/java/com/netflix/conductor/common/run/Workflow.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/Workflow.java
@@ -262,6 +262,19 @@ public class Workflow extends Auditable{
 	public void setParentWorkflowId(String parentWorkflowId) {
 		this.parentWorkflowId = parentWorkflowId;
 	}
+
+	/**
+	 * @return whether this workflow is a sub-workflow.
+	 */
+	public boolean isSubWorkflow() {
+		String parentID = getParentWorkflowId();
+
+		if (parentID == null) {
+			return false;
+		} else {
+			return !parentID.isEmpty();
+		}
+	}
 	
 	/**
 	 * @return the parentWorkflowTaskId

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -765,8 +765,9 @@ public class WorkflowExecutor {
 		// Send to atlas
 		Monitors.recordWorkflowTermination(workflow.getWorkflowType(), workflow.getStatus());
 
-		if (lazyDecider && workflow.getStatus() == WorkflowStatus.RESET && StringUtils.isNotEmpty(workflow.getParentWorkflowId())) {
-			wakeUpSweeper(workflow.getParentWorkflowId());
+		// ONECOND-794: https://jira.d3nw.com/browse/ONECOND-794
+		if (lazyDecider && workflow.getStatus() == WorkflowStatus.RESET && workflow.isSubWorkflow()) {
+			rewind(workflow.getWorkflowId(), workflow.getCorrelationId());
 		}
 	}
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
@@ -187,7 +187,8 @@ public class SubWorkflow extends WorkflowSystemTask {
 			if (restartOn == null) { // Schedule restart
 				logger.debug("Scheduled restart for the sub-workflow " + subWorkflow.getWorkflowId());
 
-				// One second default delay if not specified
+				// Half second default delay if not specified
+				// See https://jira.d3nw.com/browse/ONECOND-794
 				Long restartDelay = param.getRestartDelay();
 				if (restartDelay == null) {
 					restartDelay = 500L;


### PR DESCRIPTION
Call `rewind(...)` instead of `wakeUpSweeper(...)` to try and induce quicker sub-workflow restarts.