### PR TITLE
ONECOND-803: Service Discovery / Correlation ID

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/auth/AuthTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/auth/AuthTask.java
@@ -126,7 +126,7 @@ public class AuthTask extends WorkflowSystemTask {
 	}
 
 	private void doAuth(Task task, boolean failOnError) throws Exception {
-		AuthResponse auth = manger.authorize();
+		AuthResponse auth = manger.authorize(task.getCorrelationId());
 
 		if (!StringUtils.isEmpty(auth.getAccessToken())) {
 			task.getOutputData().put("success", true);

--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/GenericHttpTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/GenericHttpTask.java
@@ -132,7 +132,7 @@ class GenericHttpTask extends WorkflowSystemTask {
 
 		// Attach the Authorization header by adding entry to the input's headers
 		if (input.isAuthorize()) {
-			setAuthToken(input);
+			setAuthToken(input, workflow);
 		}
 
 		// Attach Authorization-Context: {SSO token} if present and enabled
@@ -240,15 +240,15 @@ class GenericHttpTask extends WorkflowSystemTask {
 		}
 	}
 
-	private void setAuthToken(Input input) throws Exception {
-		AuthResponse response = auth.authorize();
+	private void setAuthToken(Input input, Workflow workflow) throws Exception {
+		AuthResponse response = auth.authorize(workflow.getCorrelationId());
 		if (!response.hasAccessToken()) {
 			// Just log first time
 			String error = String.format(GET_ACCESS_TOKEN_FAILED, response.getError(), response.getErrorDescription());
 			logger.error(error);
 
 			// Repeat authorize
-			response = auth.authorize();
+			response = auth.authorize(workflow.getCorrelationId());
 
 			// This time need to throw exception
 			if (!response.hasAccessToken()) {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
 
 	compile project(':conductor-common')
+	compile project(':conductor-correlation')
 
 	compile 'io.reactivex:rxjava:1.2.2'
 	compile 'com.google.inject:guice:4.0+'

--- a/core/src/main/java/com/netflix/conductor/auth/AuthManager.java
+++ b/core/src/main/java/com/netflix/conductor/auth/AuthManager.java
@@ -57,6 +57,7 @@ public class AuthManager {
 	public static final String MISSING_PROPERTY = "Missing system property: ";
 	public static final String PROPERTY_URL = "conductor.auth.url";
 	public static final String PROPERTY_SERVICE = "conductor.auth.service";
+	public static final String PROPERTY_ENDPOINT = "conductor.auth.endpoint";
 	public static final String PROPERTY_CLIENT = "conductor.auth.clientId";
 	public static final String PROPERTY_SECRET = "conductor.auth.clientSecret";
 	private final ObjectMapper mapper = new ObjectMapper();
@@ -64,6 +65,7 @@ public class AuthManager {
 	private final String clientId;
 	private final String authUrl;
 	private final String authService;
+	private String authEndpoint;
 
 	@Inject
 	public AuthManager(Configuration config) {
@@ -72,6 +74,13 @@ public class AuthManager {
 			throw new IllegalArgumentException(MISSING_PROPERTY + PROPERTY_URL);
 
 		authService = config.getProperty(PROPERTY_SERVICE, null);
+		if (StringUtils.isNotEmpty(authService)) {
+			authEndpoint = config.getProperty(PROPERTY_ENDPOINT, null);
+
+			if (StringUtils.isEmpty(authEndpoint)) {
+				throw new IllegalArgumentException(MISSING_PROPERTY + PROPERTY_ENDPOINT);
+			}
+		}
 	
 		clientId = config.getProperty(PROPERTY_CLIENT, null);
 		if (StringUtils.isEmpty(clientId))
@@ -102,10 +111,9 @@ public class AuthManager {
 			if (StringUtils.isEmpty(uri)) {
 				logger.error("Service lookup failed for " + this.authUrl + " falling back to: " + this.authUrl);
 			} else {
-				url = uri + "/v1/tenant/deluxe/auth/token";
+				url = getAuthURL(uri);
 			}
 		}
-
 
 		WebResource webResource = client.resource(url);
 		ClientResponse response;
@@ -208,5 +216,9 @@ public class AuthManager {
 
 	private boolean shouldUseServiceDiscovery() {
 		return StringUtils.isNotEmpty(this.authService);
+	}
+
+	private String getAuthURL(String uri) {
+		return uri + authEndpoint;
 	}
 }

--- a/core/src/main/java/com/netflix/conductor/auth/AuthManager.java
+++ b/core/src/main/java/com/netflix/conductor/auth/AuthManager.java
@@ -52,12 +52,14 @@ public class AuthManager {
 	private static final Logger logger = LoggerFactory.getLogger(AuthManager.class);
 	public static final String MISSING_PROPERTY = "Missing system property: ";
 	public static final String PROPERTY_URL = "conductor.auth.url";
+	public static final String PROPERTY_SERVICE = "conductor.auth.service";
 	public static final String PROPERTY_CLIENT = "conductor.auth.clientId";
 	public static final String PROPERTY_SECRET = "conductor.auth.clientSecret";
 	private final ObjectMapper mapper = new ObjectMapper();
 	private final String clientSecret;
 	private final String clientId;
 	private final String authUrl;
+	private final String authService;
 
 	@Inject
 	public AuthManager(Configuration config) {
@@ -65,6 +67,8 @@ public class AuthManager {
 		if (StringUtils.isEmpty(authUrl))
 			throw new IllegalArgumentException(MISSING_PROPERTY + PROPERTY_URL);
 
+		authService = config.getProperty(PROPERTY_SERVICE, null);
+	
 		clientId = config.getProperty(PROPERTY_CLIENT, null);
 		if (StringUtils.isEmpty(clientId))
 			throw new IllegalArgumentException(MISSING_PROPERTY + PROPERTY_CLIENT);

--- a/core/src/main/java/com/netflix/conductor/core/execution/batch/SherlockBatchProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/batch/SherlockBatchProcessor.java
@@ -117,7 +117,7 @@ public class SherlockBatchProcessor extends AbstractBatchProcessor {
             // Attach the Authorization header
             Object authorize = carried.getInputData().get("authorize");
             if (Boolean.TRUE.equals(authorize)) {
-                AuthResponse auth = authManager.authorize();
+                AuthResponse auth = authManager.authorize(carried.getCorrelationId());
                 builder.header(HttpHeaders.AUTHORIZATION, "Bearer " + auth.getAccessToken());
             }
 

--- a/correlation/build.gradle
+++ b/correlation/build.gradle
@@ -1,4 +1,10 @@
 dependencies {
-    compile project(':conductor-core')
+    compile ('com.fasterxml.jackson.core:jackson-databind:2.7.5') {force=true}
+	compile ('com.fasterxml.jackson.core:jackson-core:2.7.5') {force=true}    
+    compile 'com.sun.jersey:jersey-client:1.19.+'
+    compile 'org.apache.commons:commons-lang3:3.2.1'
     compile 'org.json:json:20141113'
+	compile 'org.slf4j:slf4j-api:1.7.+'
+    
+    provided 'log4j:log4j:1.2.17'
 }

--- a/deploy.tmpl.nomad
+++ b/deploy.tmpl.nomad
@@ -167,6 +167,7 @@ job "conductor" {
 
         // Auth settings
         conductor_auth_service = "auth.service.<TLD>"
+        conductor_auth_endpoint = "/v1/tenant/deluxe/auth/token";
 
         // One MQ settings
         io_shotgun_dns = "shotgun.service.<TLD>"

--- a/deploy.tmpl.nomad
+++ b/deploy.tmpl.nomad
@@ -165,6 +165,9 @@ job "conductor" {
         workflow_elasticsearch_initial_sleep_seconds = "30"
         workflow_elasticsearch_stale_period_seconds = "300"
 
+        // Auth settings
+        conductor_auth_service = "auth.service.<TLD>"
+
         // One MQ settings
         io_shotgun_dns = "shotgun.service.<TLD>"
         io_shotgun_service = "conductor-server-<TLD>"


### PR DESCRIPTION
Changes to:

1. Use service discovery for auth, if the `conductor.auth.service` property is set.
2. If defined, increment the `sequence-no` value of the correlation ID and provide the value to the auth service when calling the `authorize(...)` method of `AuthManager`.