### PR TITLE
Prevent URI Corruption

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
@@ -100,7 +100,7 @@ public class HttpTask extends GenericHttpTask {
 					input.setUri(hostAndPort + tmp.getPath());
 				} catch (MalformedURLException e) {
 					logger.error("Unable to parse URL: " + uri, e);
-					// Oleksiy: In this case, the code will continue with the original URI value. Will that cause any issues?
+					throw new Exception("Unable to parse URL: " + uri, e);
 				}
 			}
 		}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
@@ -65,7 +65,7 @@ public class HttpTask extends GenericHttpTask {
 
 		Object request = task.getInputData().get(REQUEST_PARAMETER_NAME);
 		task.setWorkerId(config.getServerId());
-		String url = null;
+		String hostAndPort = null;
 		Input input = om.convertValue(request, Input.class);
 
 		if (request == null) {
@@ -73,9 +73,8 @@ public class HttpTask extends GenericHttpTask {
 			task.setStatus(Status.FAILED);
 			return;
 		} else if (input.getServiceDiscoveryQuery() != null) {
-			url = lookup(input.getServiceDiscoveryQuery());
+			hostAndPort = lookup(input.getServiceDiscoveryQuery());
 
-			if (null == url) {
 				logger.error("SRV lookup of: " + input.getServiceDiscoveryQuery() + " failed, falling back to URI: " + StringUtils.defaultIfEmpty(input.getUri(), "[UNDEFINED]"));
 				// Oleksiy: Should the code return from this case or is it OK to continue?
 			}
@@ -87,16 +86,16 @@ public class HttpTask extends GenericHttpTask {
 			return;
 		} else {
 			final String uri = input.getUri();
-			url = StringUtils.defaultIfEmpty(url, "");
+			hostAndPort = StringUtils.defaultIfEmpty(hostAndPort, "");
 
 			if (uri.startsWith("/")) {
-				input.setUri(url + uri);
+				input.setUri(hostAndPort + uri);
 			} else {
 				// https://jira.d3nw.com/browse/ONECOND-837
 				// Parse URI, extract the path, and append it to url
 				try {
 					URL tmp = new URL(uri);
-					input.setUri(url + tmp.getPath());
+					input.setUri(hostAndPort + tmp.getPath());
 				} catch (MalformedURLException e) {
 					logger.error("Unable to parse URL: " + uri, e);
 					// Oleksiy: In this case, the code will continue with the original URI value. Will that cause any issues?

--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
@@ -75,8 +75,10 @@ public class HttpTask extends GenericHttpTask {
 		} else if (input.getServiceDiscoveryQuery() != null) {
 			hostAndPort = lookup(input.getServiceDiscoveryQuery());
 
-				logger.error("SRV lookup of: " + input.getServiceDiscoveryQuery() + " failed, falling back to URI: " + StringUtils.defaultIfEmpty(input.getUri(), "[UNDEFINED]"));
-				// Oleksiy: Should the code return from this case or is it OK to continue?
+			if (null == hostAndPort) {
+				final String msg = "Service discovery failed for: " + input.getServiceDiscoveryQuery() + " . No records found.";
+				logger.error(msg);
+				throw new Exception(msg);
 			}
 		}
 

--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
@@ -99,8 +99,8 @@ public class HttpTask extends GenericHttpTask {
 					URL tmp = new URL(uri);
 					input.setUri(hostAndPort + tmp.getPath());
 				} catch (MalformedURLException e) {
-					logger.error("Unable to parse URL: " + uri, e);
-					throw new Exception("Unable to parse URL: " + uri, e);
+					logger.error("Unable to build endpoint URL: " + uri, e);
+					throw new Exception("Unable to build endpoint URL: " + uri, e);
 				}
 			}
 		}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpWaitTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpWaitTask.java
@@ -73,8 +73,8 @@ public class HttpWaitTask extends GenericHttpTask {
 					URL tmp = new URL(uri);
 					input.setUri(hostAndPort + tmp.getPath());
 				} catch (MalformedURLException e) {
-					logger.error("Unable to parse URL: " + uri, e);
-					throw new Exception("Unable to parse URL: " + uri, e);
+					logger.error("Unable to build endpoint URL: " + uri, e);
+					throw new Exception("Unable to build endpoint URL: " + uri, e);
 				}
 			}
 		}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpWaitTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpWaitTask.java
@@ -16,6 +16,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
 
@@ -48,10 +50,10 @@ public class HttpWaitTask extends GenericHttpTask {
 			return;
 		}
 
-		String url = null;
+		String hostAndPort = null;
 		Input input = om.convertValue(request, Input.class);
 		if (input.getServiceDiscoveryQuery() != null) {
-			url = lookup(input.getServiceDiscoveryQuery());
+			hostAndPort = lookup(input.getServiceDiscoveryQuery());
 		}
 
 		if (StringUtils.isEmpty(input.getUri())) {
@@ -59,8 +61,21 @@ public class HttpWaitTask extends GenericHttpTask {
 			task.setStatus(Task.Status.FAILED);
 			return;
 		} else {
-			if (url != null) {
-				input.setUri(url + input.getUri());
+			final String uri = input.getUri();
+			hostAndPort = StringUtils.defaultIfEmpty(hostAndPort, "");
+
+			if (uri.startsWith("/")) {
+				input.setUri(hostAndPort + uri);
+			} else {
+				// https://jira.d3nw.com/browse/ONECOND-837
+				// Parse URI, extract the path, and append it to url
+				try {
+					URL tmp = new URL(uri);
+					input.setUri(hostAndPort + tmp.getPath());
+				} catch (MalformedURLException e) {
+					logger.error("Unable to parse URL: " + uri, e);
+					throw new Exception("Unable to parse URL: " + uri, e);
+				}
 			}
 		}
 


### PR DESCRIPTION
In some cases (retry? multiple poll?) we saw the Input URI value become corrupted when service discovery would happen more than once.

The original URI would end up prefixed multiple times with SD http://host:port values.

This change uses the original URI value if it begins with a / character, otherwise tries to parse it as a URL, extracts the path value, and then uses the SD URL + path value as the URI for the request.