### PR TITLE
Check for empty service discovery query

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
@@ -70,7 +70,7 @@ public class HttpTask extends GenericHttpTask {
 			task.setStatus(Status.FAILED);
 			return;
 		} else {
-			if (input.getServiceDiscoveryQuery() != null) {
+			if (StringUtils.isNotEmpty(input.getServiceDiscoveryQuery())) {
 				url = lookup(input.getServiceDiscoveryQuery());
 			}
 		}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpWaitTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpWaitTask.java
@@ -50,7 +50,7 @@ public class HttpWaitTask extends GenericHttpTask {
 
 		String url = null;
 		Input input = om.convertValue(request, Input.class);
-		if (input.getServiceDiscoveryQuery() != null) {
+		if (StringUtils.isNotEmpty(input.getServiceDiscoveryQuery())) {
 			url = lookup(input.getServiceDiscoveryQuery());
 		}
 


### PR DESCRIPTION
Change how null or empty service discovery queries are handled.