### PR TITLE
Add health check logging

### DIFF
--- a/deploy.tmpl.nomad
+++ b/deploy.tmpl.nomad
@@ -229,7 +229,7 @@ job "conductor" {
           timeout  = "3s"
           
            check_restart {
-            limit           = 1
+            limit           = 3
             grace           = "180s"
             ignore_warnings = false
           }

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/InfoResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/InfoResource.java
@@ -82,7 +82,17 @@ public class InfoResource {
 	@ApiOperation(value = "Get the health status")
 	@Produces(MediaType.APPLICATION_JSON)
 	public Map<String, Object> health() throws IOException {
-		boolean status = client.ping();
+		boolean status = false;
+
+		try {
+			status = client.ping();
+		} catch (Exception e) {
+			logger.error("Elasticsearch health check failed: " + e.getMessage(), e);
+			throw e;
+		}
+
+		logger.info("Elasticsearch health check result: " + status);
+
 		return Collections.singletonMap("is_ping_okay", status);
 	}
 


### PR DESCRIPTION
Add some log statements to the HTTP handler for the `/v1/health` endpoint.