### PR TITLE
Add logs and error handling to decide (ONECOND-1106)

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1105,8 +1105,17 @@ public class WorkflowExecutor {
 	 * @throws Exception If there was an error - caller should retry in this case.
 	 */
 	public boolean decide(String workflowId) throws Exception {
+		if (workflowId == null || workflowId.isEmpty()) {
+			logger.error("Invoked decide() with an empty or null Workflow ID");
+			return false;
+		}
 
 		Workflow workflow = edao.getWorkflow(workflowId, true);
+		if (workflow == null) {
+			logger.error("getWorkflow() returned null for workflow: " + workflowId);
+			return false;
+		}
+
 		if (workflow.getStatus().isTerminal()) {
 			logger.debug("Invoked decide for finished workflow " + workflowId);
 			return true;

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1106,13 +1106,13 @@ public class WorkflowExecutor {
 	 */
 	public boolean decide(String workflowId) throws Exception {
 		if (workflowId == null || workflowId.isEmpty()) {
-			logger.error("Invoked decide() with an empty or null Workflow ID");
+			logger.error("ONECOND-1106: Invoked decide() with an empty or null Workflow ID");
 			return false;
 		}
 
 		Workflow workflow = edao.getWorkflow(workflowId, true);
 		if (workflow == null) {
-			logger.error("getWorkflow() returned null for workflow: " + workflowId);
+			logger.error("ONECOND-1106: getWorkflow() returned null for workflow: " + workflowId);
 			return false;
 		}
 


### PR DESCRIPTION
When decide is called with an invalid Workflow ID or if the workflow can not be found, return false and log an error message.