### PR TITLE
ONECOND-1607 match via versionId / atlasId

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/asset/MetadataAtlasMatchAction.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/asset/MetadataAtlasMatchAction.java
@@ -67,7 +67,7 @@ public class MetadataAtlasMatchAction implements JavaEventAction {
 			return Collections.emptyList();
 		}
 
-		String versionId = ScriptEvaluator.evalJq(params.atlasId, payload);
+		String versionId = ScriptEvaluator.evalJq(params.versionId, payload);
 
 		// Get the current logging context (owner)
 		String ndcValue = NDC.peek();

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1169,6 +1169,10 @@ public class WorkflowExecutor {
 		return edao.getPendingTasksByTags(taskType, tags);
 	}
 
+	public List<Task> getPendingTasksByAnyTags(String taskType, Set<String> tags) throws Exception {
+		return edao.getPendingTasksByAnyTags(taskType, tags);
+	}
+
 	public List<Workflow> getRunningWorkflows(String workflowName) throws Exception {
 		List<Workflow> allwf = edao.getPendingWorkflowsByType(workflowName);
 		return allwf;

--- a/core/src/main/java/com/netflix/conductor/dao/ExecutionDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/ExecutionDAO.java
@@ -299,6 +299,17 @@ public interface ExecutionDAO {
 		return Collections.emptyList();
 	}
 
+	/**
+	 * Returns list of the in progress tasks associated with any tags
+
+	 * @param taskType The task type currently in progress for associated workflows
+	 * @param tags The set of tags to search workflows
+	 * @return List of in progress tasks for workflows associated with any tags
+	 */
+	public default List<Task> getPendingTasksByAnyTags(String taskType, Set<String> tags) {
+		return Collections.emptyList();
+	}
+
 	public default boolean anyRunningWorkflowsByTags(Set<String> tags) {
 		return false;
 	}

--- a/postgresql-persistence/src/main/java/com/netflix/conductor/aurora/AuroraExecutionDAO.java
+++ b/postgresql-persistence/src/main/java/com/netflix/conductor/aurora/AuroraExecutionDAO.java
@@ -453,6 +453,29 @@ public class AuroraExecutionDAO extends AuroraBaseDAO implements ExecutionDAO {
 	}
 
 	/**
+	 * Function to find tasks in the workflows that matches any given tags
+	 * <p>
+	 * Includes task into result if:
+	 * workflow.tags contains ANY values from the tags parameter
+	 * and task type matches the given task type
+	 * and the task status is IN_PROGRESS
+	 *
+	 * @param tags A set of tags
+	 * @return List of tasks
+	 */
+	@Override
+	public List<Task> getPendingTasksByAnyTags(String taskType, Set<String> tags) {
+		String SQL = "SELECT t.json_data FROM task t " +
+				"INNER JOIN workflow w ON w.workflow_id = t.workflow_id " +
+				"WHERE t.task_type = ? AND t.task_status = ? AND w.tags && ?";
+
+		return queryWithTransaction(SQL, q -> q.addParameter(taskType)
+				.addParameter("IN_PROGRESS")
+				.addParameter(tags)
+				.executeAndFetch(Task.class));
+	}
+
+	/**
 	 * Function to check is there any workflows associated with given tags
 	 * Returns true if workflow.tags contains ALL values from the tags parameter
 	 * Otherwise returns false


### PR DESCRIPTION
https://jira.d3nw.com/browse/ONECOND-1607

Tags were removed from the event handler. As a result MetadataAtlasMatchAction is responsible for matching the correct waitsherlocktask to the corresponding mrv2 event message.

It will match via the following criteria:
* if VersionId exists, it will match it via featureVersionId or episodeVersionId. If it doesn't match any of the tags, then the task is not found.
* if VersionId does not exist, match it using the atlasID against the rest of the referenceKeys that is supplied by sherlock.

Refer to https://github.com/d3sw/conductor-initializer/pull/867 for the corresponding changes in conductor-initializer