### PR TITLE
ONECOND-2200: Add metrics to capture how long task polling and HTTP are taking

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/http/HttpTask.java
@@ -39,6 +39,8 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -68,7 +70,7 @@ public class HttpTask extends GenericHttpTask {
 	@Trace(operationName = "Start Http Task", resourceName = "httpTask")
 	@Override
 	public void start(Workflow workflow, Task task, WorkflowExecutor executor) throws Exception {
-
+		Instant start = Instant.now();
 		Object request = task.getInputData().get(REQUEST_PARAMETER_NAME);
 		task.setWorkerId(config.getServerId());
 		String hostAndPort = null;
@@ -139,10 +141,6 @@ public class HttpTask extends GenericHttpTask {
 					+ ",correlationId=" + workflow.getCorrelationId()
 					+ ",traceId=" + workflow.getTraceId()
 					+ ",contextUser=" + workflow.getContextUser());
-			MetricService.getInstance().httpStarted(task.getTaskType(),
-					task.getReferenceTaskName(),
-					task.getTaskDefName(),
-					serviceName);
 
 			if (input.getContentType() != null) {
 				if (input.getContentType().equalsIgnoreCase("application/x-www-form-urlencoded")) {
@@ -202,11 +200,11 @@ public class HttpTask extends GenericHttpTask {
 					+ ",contextUser=" + workflow.getContextUser()
 					+ ",traceId=" + workflow.getTraceId()
 					+ ",request=" + input.getBody());
-			MetricService.getInstance().httpComplete(task.getTaskType(),
+			MetricService.getInstance().httpExecution(task.getTaskType(),
 					task.getReferenceTaskName(),
 					task.getTaskDefName(),
 					serviceName,
-					exec_time);
+					Duration.between(start, Instant.now()).toMillis());
 		} catch (Exception ex) {
 			long exec_time = System.currentTimeMillis() - start_time;
 			logger.error("http task failed. WorkflowId=" + workflow.getWorkflowId()

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -66,6 +66,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.ws.rs.core.HttpHeaders;
+import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorkerCoordinator.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorkerCoordinator.java
@@ -32,6 +32,8 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -157,7 +159,7 @@ public class SystemTaskWorkerCoordinator {
 
 	private void pollAndExecute(WorkflowSystemTask systemTask) {
 		try {
-			
+			Instant start = Instant.now();
 			if(config.disableAsyncWorkers()) {
 				logger.warn("System Task Worker is DISABLED.  Not polling.");
 				return;
@@ -216,7 +218,7 @@ public class SystemTaskWorkerCoordinator {
 					MetricService.getInstance().systemWorkersQueueFull(name);
 				}
 			}
-			
+			MetricService.getInstance().taskExecutionTime("polling.processing", systemTask.getName(), Duration.between(start, Instant.now()).toMillis());
 		} catch (Exception e) {
 			logger.error(e.getMessage(), e);
 		}

--- a/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
@@ -172,10 +172,9 @@ public class Monitors {
 		getTimer(classQualifier, "task_queue_wait", "taskType", taskType).record(queueWaitTime, TimeUnit.MILLISECONDS);
 	}
 
-	public static void recordTaskExecutionTime(Task task, long duration, boolean includesRetries) {
+	public static void recordTaskExecutionTime(String name, Task task, long duration, boolean includesRetries) {
 		if (task.getTaskType().equals("HTTP")) {
 			getTimer(classQualifier, "http_task_execution", "taskType", task.getTaskDefName(), "includeRetries", "" + includesRetries, "status", task.getStatus().name()).record(duration, TimeUnit.MILLISECONDS);
-			//counter(classQualifier, "http_task_execution", "taskType", task.getTaskDefName(), "status", task.getStatus().name());
 		}
 
 		if (task.getTaskType().equals("WAIT")) {


### PR DESCRIPTION
- Fixed HTTP task metrics to capture true execution time
- Updated metrics to distribution so we can have avg, min and max data
- Added task polling metrics