### PR TITLE
ONECOND-2209: Account for polling clients during shutdown and prevent datasource closure when database tasks are still active

### DIFF
--- a/core/src/main/java/com/netflix/conductor/dao/MetadataDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/MetadataDAO.java
@@ -38,7 +38,7 @@ public interface MetadataDAO {
 	 * @return name of the task definition
 	 *  
 	 */
-	public abstract String createTaskDef(TaskDef taskDef);
+	String createTaskDef(TaskDef taskDef);
 
 	/**
 	 * 
@@ -46,7 +46,7 @@ public interface MetadataDAO {
 	 * @return name of the task definition
 	 *  
 	 */
-	public abstract String updateTaskDef(TaskDef taskDef);
+	String updateTaskDef(TaskDef taskDef);
 
 	/**
 	 * 
@@ -54,40 +54,40 @@ public interface MetadataDAO {
 	 * @return Task Definition
 	 *  
 	 */
-	public abstract TaskDef getTaskDef(String name);
+	TaskDef getTaskDef(String name);
 
 	/**
 	 * 
 	 * @return All the task definitions
 	 *  
 	 */
-	public abstract List<TaskDef> getAllTaskDefs();
+	List<TaskDef> getAllTaskDefs();
 
 	/**
 	 * 
 	 * @param name Name of the task
 	 */
-	public abstract void removeTaskDef(String name);
+	void removeTaskDef(String name);
 	
 	/**
 	 * 
 	 * @param def workflow definition
 	 * 
 	 */
-	public abstract void create(WorkflowDef def);
+	void create(WorkflowDef def);
 
 	/**
 	 * 
 	 * @param def workflow definition
 	 * 
 	 */
-	public abstract void update(WorkflowDef def);
+	void update(WorkflowDef def);
 
 	/**
 	 *
 	 * @param def workflow definition
 	 */
-	public default void removeWorkflow(WorkflowDef def) {
+	default void removeWorkflow(WorkflowDef def) {
 	}
 
 	/**
@@ -96,7 +96,7 @@ public interface MetadataDAO {
 	 * @return Workflow Definition
 	 * 
 	 */
-	public abstract WorkflowDef getLatest(String name);
+	WorkflowDef getLatest(String name);
 
 	/**
 	 * 
@@ -105,28 +105,28 @@ public interface MetadataDAO {
 	 * @return workflow definition
 	 * 
 	 */
-	public abstract WorkflowDef get(String name, int version);
+	WorkflowDef get(String name, int version);
 
 	/**
 	 * 
 	 * @return Names of all the workflows
 	 * 
 	 */
-	public abstract List<String> findAll();
+	List<String> findAll();
 
 	/**
 	 * 
 	 * @return List of all the workflow definitions
 	 * 
 	 */
-	public abstract List<WorkflowDef> getAll();
+	List<WorkflowDef> getAll();
 
 	/**
 	 * 
 	 * @return List of all the latest workflow definitions
 	 * 
 	 */
-	public abstract List<WorkflowDef> getAllLatest();
+	List<WorkflowDef> getAllLatest();
 
 	/**
 	 * 
@@ -134,32 +134,38 @@ public interface MetadataDAO {
 	 * @return List of all the workflow definitions
 	 * 
 	 */
-	public abstract List<WorkflowDef> getAllVersions(String name);
+	List<WorkflowDef> getAllVersions(String name);
 	
 	/**
 	 * 
 	 * @param eventHandler Event handler to be added.  
 	 * Will throw an exception if an event handler already exists with the name
 	 */
-	public abstract void addEventHandler(EventHandler eventHandler);
+	void addEventHandler(EventHandler eventHandler);
 
 	/**
 	 * 
 	 * @param eventHandler Event handler to be updated.
 	 */
-	public abstract void updateEventHandler(EventHandler eventHandler);
+	void updateEventHandler(EventHandler eventHandler);
 	
 	/**
 	 * 
 	 * @param name Removes the event handler from the system
 	 */
-	public abstract void removeEventHandlerStatus(String name);
+	void removeEventHandlerStatus(String name);
 
 	/**
 	 * 
 	 * @return All the event handlers registered in the system
 	 */
-	public List<EventHandler> getEventHandlers();
+	List<EventHandler> getEventHandlers();
+
+	/**
+	 * Validates if the datasource in use is closed
+	 * @return the status of the datasource
+	 */
+	boolean isDatasourceClosed();
 	
 	/**
 	 * 
@@ -167,19 +173,19 @@ public interface MetadataDAO {
 	 * @param activeOnly if true, returns only the active handlers
 	 * @return Returns the list of all the event handlers for a given event
 	 */
-	public List<EventHandler> getEventHandlersForEvent(String event, boolean activeOnly);
+	List<EventHandler> getEventHandlersForEvent(String event, boolean activeOnly);
 
-	public default List<Pair<String, String>> getConfigs() {
+	default List<Pair<String, String>> getConfigs() {
 		return Collections.emptyList();
 	}
 
 
-	public default void addConfig(String name, String value) {
+	default void addConfig(String name, String value) {
 	}
 
-	public default void updateConfig(String name, String value) {
+	default void updateConfig(String name, String value) {
 	}
 
-	public default void deleteConfig(String name) {
+	default void deleteConfig(String name) {
 	}
 }

--- a/core/src/main/java/com/netflix/conductor/dao/MetricsDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/MetricsDAO.java
@@ -30,6 +30,12 @@ public interface MetricsDAO {
 
 	Map<String, Object> getMetrics();
 
+	/**
+	 * Validates if the datasource in use is closed
+	 * @return the status of the datasource
+	 */
+	boolean isDatasourceClosed();
+
 	default List<String> getStuckChecksums(Long startTime, Long endTime) {return new ArrayList<>();}
 
 }

--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -110,6 +110,10 @@ public class ExecutionService {
 
 	public List<Task> poll(String taskType, String workerId, String domain, int count, int timeoutInMilliSecond) throws Exception {
 
+		// return empty list to polling clients (workflowcomposer) if the datasource is closed
+		if (metadata.isDatasourceClosed())
+			return new ArrayList<>();
+
 		String queueName = QueueUtils.getQueueName(taskType, domain);
 
 		List<String> taskIds = queue.pop(queueName, count, timeoutInMilliSecond);

--- a/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/ElasticSearch5MetadataDAO.java
+++ b/es5-persistence/src/main/java/com/netflix/conductor/dao/es5/ElasticSearch5MetadataDAO.java
@@ -322,6 +322,11 @@ public class ElasticSearch5MetadataDAO extends ElasticSearch5BaseDAO implements 
 	}
 
 	@Override
+	public boolean isDatasourceClosed() {
+		return false;
+	}
+
+	@Override
 	public List<EventHandler> getEventHandlersForEvent(String event, boolean activeOnly) {
 		if (logger.isDebugEnabled())
 			logger.debug("getEventHandlersForEvent: event={}, activeOnly={}", event, activeOnly);

--- a/es6rest-persistence/src/main/java/com/netflix/conductor/dao/es6rest/dao/Elasticsearch6RestMetadataDAO.java
+++ b/es6rest-persistence/src/main/java/com/netflix/conductor/dao/es6rest/dao/Elasticsearch6RestMetadataDAO.java
@@ -319,6 +319,11 @@ public class Elasticsearch6RestMetadataDAO extends Elasticsearch6RestAbstractDAO
     }
 
     @Override
+    public boolean isDatasourceClosed() {
+        return false;
+    }
+
+    @Override
     public List<EventHandler> getEventHandlersForEvent(String event, boolean activeOnly) {
         if (logger.isDebugEnabled())
             logger.debug("getEventHandlersForEvent: event={}, activeOnly={}", event, activeOnly);

--- a/es6rest-persistence/src/main/java/com/netflix/conductor/dao/es6rest/dao/Elasticsearch6RestMetricsDAO.java
+++ b/es6rest-persistence/src/main/java/com/netflix/conductor/dao/es6rest/dao/Elasticsearch6RestMetricsDAO.java
@@ -193,6 +193,11 @@ public class Elasticsearch6RestMetricsDAO extends Elasticsearch6RestAbstractDAO 
 		return new HashMap<>(metrics);
 	}
 
+	@Override
+	public boolean isDatasourceClosed() {
+		return false;
+	}
+
 	@Deprecated
 	public Map<String, Object> getAdminCounters() {
 		Map<String, AtomicLong> metrics = new ConcurrentHashMap<>();

--- a/jersey/src/main/java/com/netflix/conductor/server/resources/InfoResource.java
+++ b/jersey/src/main/java/com/netflix/conductor/server/resources/InfoResource.java
@@ -86,7 +86,8 @@ public class InfoResource {
 			boolean status = false;
 
 			try {
-				status = metricsDAO.ping();
+				// bypass datastore ping if it is already closed
+				status = metricsDAO.isDatasourceClosed() ? true : metricsDAO.ping();
 			} catch (Exception e) {
 				logger.error("Db health check failed: " + e.getMessage(), e);
 				throw e;

--- a/postgresql-persistence/src/main/java/com/netflix/conductor/aurora/AuroraBaseDAO.java
+++ b/postgresql-persistence/src/main/java/com/netflix/conductor/aurora/AuroraBaseDAO.java
@@ -38,6 +38,11 @@ public abstract class AuroraBaseDAO {
 		this.mapper = mapper;
 	}
 
+	protected boolean isDatasourceClosed() {
+		HikariDataSource datasource = (HikariDataSource) dataSource;
+		return datasource.isClosed();
+	}
+
 	void withTransaction(Consumer<Connection> consumer) {
 		getWithTransaction(connection -> {
 			consumer.accept(connection);
@@ -46,8 +51,7 @@ public abstract class AuroraBaseDAO {
 	}
 
 	<R> R getWithTransaction(TransactionalFunction<R> function) {
-		HikariDataSource datasource = (HikariDataSource) dataSource;
-		if (datasource.isClosed()) {
+		if (isDatasourceClosed()) {
 			throw new RuntimeException(DATASOURCE_SHUTDOWN_MSG);
 		}
 

--- a/postgresql-persistence/src/main/java/com/netflix/conductor/aurora/AuroraMetricsDAO.java
+++ b/postgresql-persistence/src/main/java/com/netflix/conductor/aurora/AuroraMetricsDAO.java
@@ -45,6 +45,11 @@ public class AuroraMetricsDAO extends AuroraBaseDAO implements MetricsDAO {
 		return Collections.emptyMap();
 	}
 
+	@Override
+	public boolean isDatasourceClosed() {
+		return super.isDatasourceClosed();
+	}
+
 	// Wait until all futures completed
 	private void waitCompleted(List<Future<?>> futures) {
 		for (Future<?> future : futures) {

--- a/postgresql-persistence/src/main/java/com/netflix/conductor/aurora/AuroraTaskShutdown.java
+++ b/postgresql-persistence/src/main/java/com/netflix/conductor/aurora/AuroraTaskShutdown.java
@@ -1,0 +1,16 @@
+package com.netflix.conductor.aurora;
+
+public interface AuroraTaskShutdown {
+
+    /**
+     * Shuts down active aurora execution task
+     */
+    void shutdown();
+
+    /**
+     * Checks if this task is still in progress after a shutdown instruction
+     * Helps stall dependent services from shutting down/closing before completion
+     * @return the state of the executor task
+     */
+    boolean isTaskTerminated();
+}

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisMetadataDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisMetadataDAO.java
@@ -276,7 +276,12 @@ public class RedisMetadataDAO extends BaseDynoDAO implements MetadataDAO {
 		});
 		return handlers;
 	}
-	
+
+	@Override
+	public boolean isDatasourceClosed() {
+		return false;
+	}
+
 	private void index(EventHandler eh) {
 		String event = eh.getEvent();
 		String key = nsKey(EVENT_HANDLERS_BY_EVENT, event);

--- a/server/src/main/java/com/netflix/conductor/server/ServerShutdown.java
+++ b/server/src/main/java/com/netflix/conductor/server/ServerShutdown.java
@@ -55,8 +55,11 @@ public class ServerShutdown {
 			// close all open connections
 			HikariDataSource datasource = (HikariDataSource) dataSource;
 			datasource.getHikariPoolMXBean().softEvictConnections();
-			while (datasource.getHikariPoolMXBean().getActiveConnections() > 0) {
-				logger.trace("waiting for {} active connections to complete shutdown...", datasource.getHikariPoolMXBean().getActiveConnections());
+			while (datasource.getHikariPoolMXBean().getActiveConnections() > 0 ||
+					!auroraMetadataDAO.isTaskTerminated() ||
+					!auroraQueueDAO.isTaskTerminated()) {
+				logger.debug("waiting for {} active connections to complete shutdown...",
+						datasource.getHikariPoolMXBean().getActiveConnections());
 			}
 			datasource.close();
 		}


### PR DESCRIPTION
**Key changes implemented**

- Account for task polling clients when datasource pool is closed
- Do not close the connection pool if the database tasks hasn't successfully terminated
- Bypass database metrics check in health-check status if the pool has been closed. Nomad does not have traffic block to prevent new requests from coming in after a SIGTERM instruction